### PR TITLE
remove endpoint register from trace service

### DIFF
--- a/mock-collector/src/main/java/org/apache/skywalking/plugin/test/mockcollector/mock/rest/MockTraceSegmentCollectServletHandler.java
+++ b/mock-collector/src/main/java/org/apache/skywalking/plugin/test/mockcollector/mock/rest/MockTraceSegmentCollectServletHandler.java
@@ -84,12 +84,6 @@ public class MockTraceSegmentCollectServletHandler extends JettyJsonHandler {
                 spanBuilder.ref(new Span.SegmentRef(ref));
             }
 
-            // Endpoint register
-            ValidateData.INSTANCE.getRegistryItem()
-                                 .registryOperationName(
-                                     new RegistryItem.OperationName(traceSegmentObject.getServiceId(),
-                                                                    spanObject.getOperationName()));
-
             segmentBuilder.addSpan(spanBuilder);
         }
 


### PR DESCRIPTION
follow apache/skywalking#4570 , mock-collector have to remove the endpoint register by trace service.