### PR TITLE
Fix miss `%s` bug and modify noncompliant code

### DIFF
--- a/validator/src/main/java/org/apache/skywalking/plugin/test/agent/tool/validator/assertor/exception/TagValueNotEqualsException.java
+++ b/validator/src/main/java/org/apache/skywalking/plugin/test/agent/tool/validator/assertor/exception/TagValueNotEqualsException.java
@@ -32,6 +32,6 @@ public class TagValueNotEqualsException extends AssertFailedException {
 
     @Override
     public String getCauseMessage() {
-        return String.format("[tag(%s) value]: expected=>{%s}, actual=>{%s}%n", tagKey, expected, actual);
+        return String.format("[tag(%s) value]: expected=>{%s}, actual=>{%s}\n", tagKey, expected, actual);
     }
 }

--- a/validator/src/main/java/org/apache/skywalking/plugin/test/agent/tool/validator/assertor/exception/TagValueNotEqualsException.java
+++ b/validator/src/main/java/org/apache/skywalking/plugin/test/agent/tool/validator/assertor/exception/TagValueNotEqualsException.java
@@ -32,6 +32,6 @@ public class TagValueNotEqualsException extends AssertFailedException {
 
     @Override
     public String getCauseMessage() {
-        return String.format("[tag(%s) value]: expected=>{}, actual=>{%s}\n", tagKey, expected, actual);
+        return String.format("[tag(%s) value]: expected=>{%s}, actual=>{%s}%n", tagKey, expected, actual);
     }
 }


### PR DESCRIPTION
1.  miss `%s` format for `expected` value
2. Noncompliant: %n should be used in place of \n to produce the platform-specific line separator