### PR TITLE
Instead of traditional container class using the concurrent container

### DIFF
--- a/mock-collector/src/main/java/org/apache/skywalking/plugin/test/mockcollector/entity/SegmentItem.java
+++ b/mock-collector/src/main/java/org/apache/skywalking/plugin/test/mockcollector/entity/SegmentItem.java
@@ -17,8 +17,8 @@
 
 package org.apache.skywalking.plugin.test.mockcollector.entity;
 
-import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 public class SegmentItem {
     private String serviceName;
@@ -26,7 +26,7 @@ public class SegmentItem {
 
     public SegmentItem(String serviceName) {
         this.serviceName = serviceName;
-        segments = new ArrayList<>();
+        segments = new CopyOnWriteArrayList<>();
     }
 
     public void addSegments(Segment item) {

--- a/mock-collector/src/main/java/org/apache/skywalking/plugin/test/mockcollector/entity/SegmentItems.java
+++ b/mock-collector/src/main/java/org/apache/skywalking/plugin/test/mockcollector/entity/SegmentItems.java
@@ -17,14 +17,14 @@
 
 package org.apache.skywalking.plugin.test.mockcollector.entity;
 
-import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 public class SegmentItems {
     private Map<String, SegmentItem> segmentItems;
 
     public SegmentItems() {
-        this.segmentItems = new HashMap<>();
+        this.segmentItems = new ConcurrentHashMap<>();
     }
 
     public SegmentItems addSegmentItem(String serviceName, Segment segment) {

--- a/mock-collector/src/main/java/org/apache/skywalking/plugin/test/mockcollector/entity/ValidateData.java
+++ b/mock-collector/src/main/java/org/apache/skywalking/plugin/test/mockcollector/entity/ValidateData.java
@@ -25,11 +25,11 @@ public class ValidateData {
         segmentItem = new SegmentItems();
     }
 
-    public SegmentItems getSegmentItem() {
+    public synchronized SegmentItems getSegmentItem() {
         return segmentItem;
     }
 
-    public static void clearData() {
+    public synchronized void clearData() {
         INSTANCE.segmentItem = new SegmentItems();
     }
 }

--- a/mock-collector/src/main/java/org/apache/skywalking/plugin/test/mockcollector/service/ClearReceiveDataService.java
+++ b/mock-collector/src/main/java/org/apache/skywalking/plugin/test/mockcollector/service/ClearReceiveDataService.java
@@ -34,7 +34,7 @@ public class ClearReceiveDataService extends HttpServlet {
         resp.setContentType("text/json");
         resp.setCharacterEncoding("utf-8");
         resp.setStatus(200);
-        ValidateData.clearData();
+        ValidateData.INSTANCE.clearData();
         Writer out = resp.getWriter();
         out.flush();
         out.close();


### PR DESCRIPTION
In general, mock-collector just works in the single-thread environment. but we get the feedback that it works broke because of concurrency. Like 
[apache/skywalking#5244](https://github.com/apache/skywalking/issues/5254). 
So, I am going to instead of traditional container classes using the concurrent container.