### PR TITLE
fix the field named isError is no mapping when serialization

### DIFF
--- a/validator/src/main/java/org/apache/skywalking/plugin/test/agent/tool/validator/entity/SegmentForRead.java
+++ b/validator/src/main/java/org/apache/skywalking/plugin/test/agent/tool/validator/entity/SegmentForRead.java
@@ -176,8 +176,8 @@ public class SegmentForRead implements Segment {
             this.componentName = componentName;
         }
 
-        public void setError(String error) {
-            isError = error;
+        public void setIsError(String isError) {
+            this.isError = isError;
         }
 
         public void setSpanType(String spanType) {


### PR DESCRIPTION
fix the field named isError is no mapping when serialization