### PR TITLE
Fix a typo

### DIFF
--- a/validator/src/main/java/org/apache/skywalking/plugin/test/agent/tool/validator/assertor/DataAssert.java
+++ b/validator/src/main/java/org/apache/skywalking/plugin/test/agent/tool/validator/assertor/DataAssert.java
@@ -25,7 +25,7 @@ import org.apache.skywalking.plugin.test.agent.tool.validator.entity.Data;
 public class DataAssert {
 
     public static void assertEquals(Data excepted, Data actual) {
-        log.info("excepted data:\n{}", new GsonBuilder().setPrettyPrinting().create().toJson(excepted));
+        log.info("expected data:\n{}", new GsonBuilder().setPrettyPrinting().create().toJson(excepted));
         log.info("actual data:\n{}", new GsonBuilder().setPrettyPrinting().create().toJson(actual));
         SegmentItemsAssert.assertEquals(excepted.segmentItems(), actual.segmentItems());
         MeterItemsAssert.assertEquals(excepted.meterItems(), actual.meterItems());


### PR DESCRIPTION
A grep of `excepted` shows that there are a lot of places where `excepted` is used for `expected`.

If a complete correction of `excepted` is desired, I am willing to do it.