### PR TITLE
compatible with m1 Mac osx-aarch_64

### DIFF
--- a/mock-collector/pom.xml
+++ b/mock-collector/pom.xml
@@ -38,8 +38,8 @@
         <protocol.workingDirectory>${project.basedir}/target/protocol</protocol.workingDirectory>
         <protocol.repos>https://github.com/apache/skywalking-data-collect-protocol.git</protocol.repos>
         <protobuf-maven-plugin.version>0.6.1</protobuf-maven-plugin.version>
-        <com.google.protobuf.protoc.version>3.3.0</com.google.protobuf.protoc.version>
-        <protoc-gen-grpc-java.plugin.version>1.8.0</protoc-gen-grpc-java.plugin.version>
+        <com.google.protobuf.protoc.version>3.17.3</com.google.protobuf.protoc.version>
+        <protoc-gen-grpc-java.plugin.version>1.42.1</protoc-gen-grpc-java.plugin.version>
         <protobuf-java-util.version>3.11.4</protobuf-java-util.version>
     </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
         <junit.version>4.11</junit.version>
         <guava.version>20.0</guava.version>
         <gson.version>2.8.6</gson.version>
-        <grpc.version>1.26.0</grpc.version>
+        <grpc.version>1.42.1</grpc.version>
         <lombok.version>1.18.10</lombok.version>
         <snakeyaml.version>1.24</snakeyaml.version>
         <slf4j.version>1.7.25</slf4j.version>


### PR DESCRIPTION
Preconditions of fixing issue https://github.com/apache/skywalking/issues/8223 , m1 run skywalking test scenario have to update protoc version.