### PR TITLE
exit 0 when verify success

### DIFF
--- a/validator/src/main/java/org/apache/skywalking/plugin/test/agent/tool/Main.java
+++ b/validator/src/main/java/org/apache/skywalking/plugin/test/agent/tool/Main.java
@@ -50,6 +50,7 @@ public class Main {
                 try {
                     DataAssert.assertEquals(expectedData, actualData);
                     log.info("{} assert successful.", "segment items");
+                    return true;
                 } catch (AssertFailedException e) {
                     log.error(
                         "assert failed:\nexpected data: {}\nactual data: {}\ncause by: {}",


### PR DESCRIPTION
the `run.sh` in jvm-container in skywaling-agent project will check the `skywalking-validator.jar` exit code. But now it will return 1 not 0 even verify success.

```shell
echo "To validate"
java -jar \
    -Xmx256m -Xms256m \
    -DcaseName="${SCENARIO_NAME}-${SCENARIO_VERSION}" \
    -DtestCasePath=${SCENARIO_HOME}/data/ \
    ${TOOLS_HOME}/skywalking-validator.jar 1>${LOGS_HOME}/validatolr.out
status=$?

if [[ $status -eq 0 ]]; then
  echo "Scenario[${SCENARIO_NAME}-${SCENARIO_VERSION}] passed!" >&2
else
  cat ${SCENARIO_HOME}/data/actualData.yaml >&2
  exitOnError "Scenario[${SCENARIO_NAME}-${SCENARIO_VERSION}] failed!"
fi
```