### PR TITLE
Support `start with` and `end with`

### DIFF
--- a/validator/src/main/java/org/apache/skywalking/plugin/test/agent/tool/validator/assertor/ExpressOperator.java
+++ b/validator/src/main/java/org/apache/skywalking/plugin/test/agent/tool/validator/assertor/ExpressOperator.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.skywalking.plugin.test.agent.tool.validator.assertor;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public enum ExpressOperator {
+    NULL("null", false),
+    NOT_NULL("not null", false),
+    NOT_BLANK("not blank", false),
+    NOT_EQUALS("nq",true),
+    EQUALS("eq",true),
+    GREAT_THAN("gt",true),
+    GREAT_EQUAL("ge",true),
+    START_WITH("start with",true),
+    END_WITH("end with",true),
+    ;
+    private final String prefix;
+    private final boolean hasValue;
+
+    public static ExpressOperator parse(String express) {
+        if (express == null) {
+            return null;
+        }
+
+        String expressTrim = express.trim();
+        for (ExpressOperator operator : ExpressOperator.values()) {
+            if (expressTrim.startsWith(operator.getPrefix())) {
+                return operator;
+            }
+        }
+
+        return null;
+    }
+
+    public static String getExpectedValue(ExpressOperator operator, String express) {
+        if (operator.hasValue) {
+            return express.substring(operator.prefix.length()).trim();
+        }
+        return null;
+    }
+}

--- a/validator/src/main/java/org/apache/skywalking/plugin/test/agent/tool/validator/assertor/ExpressParser.java
+++ b/validator/src/main/java/org/apache/skywalking/plugin/test/agent/tool/validator/assertor/ExpressParser.java
@@ -19,13 +19,15 @@ package org.apache.skywalking.plugin.test.agent.tool.validator.assertor;
 
 import org.apache.skywalking.plugin.test.agent.tool.validator.assertor.element.ElementAssertor;
 import org.apache.skywalking.plugin.test.agent.tool.validator.assertor.element.EqualsAssertor;
+import org.apache.skywalking.plugin.test.agent.tool.validator.assertor.element.EndWithAssertor;
 import org.apache.skywalking.plugin.test.agent.tool.validator.assertor.element.GreatThanAssertor;
-import org.apache.skywalking.plugin.test.agent.tool.validator.assertor.element.GreetEqualAssertor;
+import org.apache.skywalking.plugin.test.agent.tool.validator.assertor.element.GreatEqualAssertor;
 import org.apache.skywalking.plugin.test.agent.tool.validator.assertor.element.NoopAssertor;
 import org.apache.skywalking.plugin.test.agent.tool.validator.assertor.element.NotBlankAssertor;
 import org.apache.skywalking.plugin.test.agent.tool.validator.assertor.element.NotEqualsAssertor;
 import org.apache.skywalking.plugin.test.agent.tool.validator.assertor.element.NotNullAssertor;
 import org.apache.skywalking.plugin.test.agent.tool.validator.assertor.element.NullAssertor;
+import org.apache.skywalking.plugin.test.agent.tool.validator.assertor.element.StartWithAssertor;
 
 public class ExpressParser {
     public static ElementAssertor parse(String express) {
@@ -33,36 +35,34 @@ public class ExpressParser {
             return new NoopAssertor();
         }
 
-        String expressTrim = express.trim();
-        if (expressTrim.equals("not null")) {
-            return new NotNullAssertor();
+        ExpressOperator expressOperator = ExpressOperator.parse(express);
+        if (expressOperator == null) {
+            return new EqualsAssertor(express);
         }
 
-        if (expressTrim.equals("not blank")) {
-            return new NotBlankAssertor();
-        }
+        String expectedValue = ExpressOperator.getExpectedValue(expressOperator, express);
 
-        if (expressTrim.equals("null")) {
-            return new NullAssertor();
+        switch (expressOperator) {
+            case NULL:
+                return new NullAssertor();
+            case NOT_NULL:
+                return new NotNullAssertor();
+            case NOT_BLANK:
+                return new NotBlankAssertor();
+            case EQUALS:
+                return new EqualsAssertor(expectedValue);
+            case NOT_EQUALS:
+                return new NotEqualsAssertor(expectedValue);
+            case GREAT_THAN:
+                return new GreatThanAssertor(expectedValue);
+            case GREAT_EQUAL:
+                return new GreatEqualAssertor(expectedValue);
+            case START_WITH:
+                return new StartWithAssertor(expectedValue);
+            case END_WITH:
+                return new EndWithAssertor(expectedValue);
+            default:
+                return new EqualsAssertor(express);
         }
-
-        String[] expressSegment = expressTrim.split(" ");
-        if (expressSegment.length == 1) {
-            return new EqualsAssertor(expressSegment[0]);
-        } else if (expressSegment.length == 2) {
-            String exceptedValue = expressSegment[1];
-            switch (expressSegment[0].trim()) {
-                case "nq":
-                    return new NotEqualsAssertor(exceptedValue);
-                case "eq":
-                    return new EqualsAssertor(exceptedValue);
-                case "gt":
-                    return new GreatThanAssertor(exceptedValue);
-                case "ge":
-                    return new GreetEqualAssertor(exceptedValue);
-            }
-        }
-
-        return new EqualsAssertor(express);
     }
 }

--- a/validator/src/main/java/org/apache/skywalking/plugin/test/agent/tool/validator/assertor/element/EndWithAssertor.java
+++ b/validator/src/main/java/org/apache/skywalking/plugin/test/agent/tool/validator/assertor/element/EndWithAssertor.java
@@ -20,15 +20,15 @@ package org.apache.skywalking.plugin.test.agent.tool.validator.assertor.element;
 
 import org.apache.skywalking.plugin.test.agent.tool.validator.assertor.exception.ValueAssertFailedException;
 
-public class GreetEqualAssertor extends ElementAssertor {
-    public GreetEqualAssertor(String exceptedValue) {
+public class EndWithAssertor extends ElementAssertor {
+    public EndWithAssertor(String exceptedValue) {
         super(exceptedValue);
     }
 
     @Override
     public void assertValue(String desc, String actualValue) {
-        if (Double.parseDouble(actualValue) < Double.parseDouble(exceptedValue)) {
-            throw new ValueAssertFailedException(desc, " ge " + exceptedValue, actualValue);
+        if (actualValue == null || !actualValue.endsWith(exceptedValue)) {
+            throw new ValueAssertFailedException(desc, " end with " + exceptedValue, actualValue);
         }
     }
 }

--- a/validator/src/main/java/org/apache/skywalking/plugin/test/agent/tool/validator/assertor/element/GreatEqualAssertor.java
+++ b/validator/src/main/java/org/apache/skywalking/plugin/test/agent/tool/validator/assertor/element/GreatEqualAssertor.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.skywalking.plugin.test.agent.tool.validator.assertor.element;
+
+import org.apache.skywalking.plugin.test.agent.tool.validator.assertor.exception.ValueAssertFailedException;
+
+public class GreatEqualAssertor extends ElementAssertor {
+    public GreatEqualAssertor(String exceptedValue) {
+        super(exceptedValue);
+    }
+
+    @Override
+    public void assertValue(String desc, String actualValue) {
+        if (Double.parseDouble(actualValue) < Double.parseDouble(exceptedValue)) {
+            throw new ValueAssertFailedException(desc, " ge " + exceptedValue, actualValue);
+        }
+    }
+}

--- a/validator/src/main/java/org/apache/skywalking/plugin/test/agent/tool/validator/assertor/element/StartWithAssertor.java
+++ b/validator/src/main/java/org/apache/skywalking/plugin/test/agent/tool/validator/assertor/element/StartWithAssertor.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.skywalking.plugin.test.agent.tool.validator.assertor.element;
+
+import org.apache.skywalking.plugin.test.agent.tool.validator.assertor.exception.ValueAssertFailedException;
+
+public class StartWithAssertor extends ElementAssertor {
+    public StartWithAssertor(String exceptedValue) {
+        super(exceptedValue);
+    }
+
+    @Override
+    public void assertValue(String desc, String actualValue) {
+        if (actualValue == null || !actualValue.startsWith(exceptedValue)) {
+            throw new ValueAssertFailedException(desc, " start with " + exceptedValue, actualValue);
+        }
+    }
+}

--- a/validator/src/test/resources/expectedData.yaml
+++ b/validator/src/test/resources/expectedData.yaml
@@ -100,7 +100,7 @@ logItems:
         body:
           type: ''
           content:
-            text: "something text to log"
+            text: "start with something text"
         tags:
           data:
             - key: foo
@@ -128,7 +128,7 @@ logItems:
         body:
           type: ''
           content:
-            yaml: "something yaml to log"
+            yaml: "end with to log"
         traceContext: {}
         tags: {}
         layer: ''


### PR DESCRIPTION
Related to https://github.com/apache/skywalking-java/pull/382.

Here are the brief changes:
1. Introduce the enum `ExpressOperator` to refactor `ExpressParser`
2. Support `start with` and `end with` operators
3. Fix wrong spelling