### PR TITLE
Enhance the segment span validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ on:
       - 'v*'
 
 jobs:
-  CI:
+  CI-on-Ubuntu:
     runs-on: ubuntu-18.04
     timeout-minutes: 180
     strategy:


### PR DESCRIPTION
Currently, in the Go version of the agent, the order of spans in a segment can become unstable due to fast execution, although the span IDs are always ordered. To address this issue, this PR is submitted to allow validation of corresponding data in the segment when spans are out of order based on their span IDs.