### PR TITLE
Upgrade lombok version for compile error

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
         <guava.version>20.0</guava.version>
         <gson.version>2.8.9</gson.version>
         <grpc.version>1.42.1</grpc.version>
-        <lombok.version>1.18.24</lombok.version>
+        <lombok.version>1.18.30</lombok.version>
         <snakeyaml.version>1.31</snakeyaml.version>
         <slf4j.version>1.7.25</slf4j.version>
         <log4j.version>2.17.1</log4j.version>


### PR DESCRIPTION
## Problem
When I run 'bash ./test/plugin/run.sh -f sofarpc-scenario' at SKYWALKING_JAVA_HOME compile error occur.
```
Class com.sun.tools.javac.tree.JCTree$JCImport does not have member field 'com.sun.tools.javac.tree.JCTree qualid'
````

[Lombok Change log ](https://projectlombok.org/changelog) says lombok support JDK21  in  1.18.30.
I have checked , change lombok version to  1.18.30 can fix this problem.




## Environment
### Java
```
openjdk version "21.0.2" 2024-01-16 LTS
OpenJDK Runtime Environment Corretto-21.0.2.13.1 (build 21.0.2+13-LTS)
OpenJDK 64-Bit Server VM Corretto-21.0.2.13.1 (build 21.0.2+13-LTS, mixed mode, sharing)
```

### OS
```
Macbook Pro M3
osx: 14.1 (23B2073)
```



